### PR TITLE
Update Arithmetic Unit Division

### DIFF
--- a/source/csm_units/unitbase.hpp
+++ b/source/csm_units/unitbase.hpp
@@ -111,7 +111,7 @@ class UnitBase {
 
   // double / compound
   friend constexpr auto operator/(Arithmetic auto lhs, UnitBase rhs) noexcept {
-    return (UnitBase<ExponentsFlip<Powers>, decltype(lhs)>(lhs / rhs.data));
+    return (UnitBase<ExponentsFlip<Powers>, Data>(lhs / rhs.data));
   }
 
   // * operator overloads


### PR DESCRIPTION
When dividing an arithmetic by a unit it forces the new unit to take the underlying data type of the rhs unit.