### PR TITLE
negative integer powers and simplified calcs

### DIFF
--- a/source/csm_units/definition.hpp
+++ b/source/csm_units/definition.hpp
@@ -61,25 +61,22 @@ class Definition {
                                       std::ratio<ConvType::den, ConvType::num>>;
 
   template <IsDefinition DR>
-    requires std::same_as<DimenType, DimensionFlip<typename DR::DimenType>>
   [[nodiscard]] constexpr auto operator*(DR /*rhs*/) const noexcept {
-    return CSMUNITS_VALUE_TYPE();
-  }
-
-  template <IsDefinition DR>
-  [[nodiscard]] constexpr auto operator*(DR /*rhs*/) const noexcept {
-    return DefinitionMultiply<DR>();
-  }
-
-  template <IsDefinition DR>
-    requires std::same_as<DimenType, typename DR::DimenType>
-  [[nodiscard]] constexpr auto operator/(DR /*rhs*/) const noexcept {
-    return CSMUNITS_VALUE_TYPE();
+    if constexpr (std::same_as<DimenType,
+                               DimensionFlip<typename DR::DimenType>>) {
+      return static_cast<CSMUNITS_VALUE_TYPE>(1.0);
+    } else {
+      return DefinitionMultiply<DR>();
+    }
   }
 
   template <IsDefinition DR>
   [[nodiscard]] constexpr auto operator/(DR /*rhs*/) const noexcept {
-    return DefinitionDivide<DR>();
+    if constexpr (std::same_as<DimenType, typename DR::DimenType>) {
+      return static_cast<CSMUNITS_VALUE_TYPE>(1.0);
+    } else {
+      return DefinitionDivide<DR>();
+    }
   }
 };
 

--- a/source/csm_units/math.hpp
+++ b/source/csm_units/math.hpp
@@ -9,31 +9,16 @@
 
 namespace csm_units {
 
-namespace detail {
-
-template <int N>
-struct UnitPow {
-  static_assert(N > 0,
-                "Unit power function only accepts non-negative integers.");
-
-  [[nodiscard]] constexpr static auto Calc(IsUnit auto&& unit) noexcept {
-    return unit * UnitPow<N - 1>::Calc(std::forward<decltype(unit)>(unit));
-  }
-};
-
-template <>
-struct UnitPow<0> {
-  [[nodiscard]] constexpr static auto Calc(IsUnit auto&& /*unit*/) noexcept {
-    return 1.0;
-  }
-};
-
-}  // namespace detail
-
 // Unit to positive integer power
 template <int N>
 [[nodiscard]] constexpr auto UnitPow(IsUnit auto&& unit) noexcept {
-  return detail::UnitPow<N>::Calc(std::forward<decltype(unit)>(unit));
+  if constexpr (N > 0) {
+    return unit * UnitPow<N - 1>(std::forward<decltype(unit)>(unit));
+  } else if constexpr (N < 0) {
+    return 1.0 / (UnitPow<-1 * N>(std::forward<decltype(unit)>(unit)));
+  } else {
+    return 1.0;
+  }
 }
 
 // Alias for squaring a unit

--- a/source/csm_units/unit.hpp
+++ b/source/csm_units/unit.hpp
@@ -181,7 +181,7 @@ constexpr auto operator*(U lhs, D rhs) noexcept {
     return lhs.data;
   } else {
     auto result = Unit<U::def * rhs, typename U::ValueType>();
-    result.data = lhs.data;
+    result.data = lhs.data / rhs.Get();
     return result;
   }
 }
@@ -198,7 +198,7 @@ constexpr auto operator/(U lhs, D rhs) noexcept {
     return lhs.data;
   } else {
     auto result = Unit<U::def / rhs, typename U::ValueType>();
-    result.data = lhs.data;
+    result.data = lhs.data * rhs.Get();
     return result;
   }
 }

--- a/source/csm_units/unit.hpp
+++ b/source/csm_units/unit.hpp
@@ -138,39 +138,31 @@ class Unit {
     return lhs;
   }
 
-  template <SameDimensionAs<Unit> U>
-  constexpr friend auto operator/(Unit lhs, U rhs) noexcept {
-    return lhs.data / rhs.data;  // Unitless return since dimensions cancel
-  }
-
-  // Operator overloads for interactions with Units of specific relative
-  // dimensions
-  template <IsUnit U>
-    requires std::same_as<typename U::DefType::DimenType,
-                          DimensionFlip<typename DefType::DimenType>>
-  constexpr friend auto operator*(Unit lhs, U rhs) noexcept {
-    return lhs.data * rhs.data;  // Unitless return since dimensions cancel
-  }
-
   // Operator overloads for interactions with other Units
   // Unit storage ValueType follows regular c++ promotion rules
   template <IsUnit U>
-    requires(not std::same_as<typename U::DefType::DimenType,
-                              DimensionFlip<typename DefType::DimenType>>)
   constexpr friend auto operator*(Unit lhs, const U& rhs) noexcept {
-    using ResultType = decltype(lhs.data * rhs.data);
-    auto result = Unit<def * U::def, ResultType>();
-    result.data = lhs.data * rhs.data;  // bypass constructor SI cast
-    return result;
+    if constexpr (std::same_as<typename U::DefType::DimenType,
+                               DimensionFlip<typename DefType::DimenType>>) {
+      return lhs.data * rhs.data;  // Unitless return since dimensions cancel
+    } else {
+      using ResultType = decltype(lhs.data * rhs.data);
+      auto result = Unit<def * U::def, ResultType>();
+      result.data = lhs.data * rhs.data;  // bypass constructor SI cast
+      return result;
+    }
   }
 
   template <IsUnit U>
-    requires(not SameDimensionAs<Unit, U>)  // Otherwise dimensionless return
   constexpr friend auto operator/(Unit lhs, const U& rhs) noexcept {
-    using ResultType = decltype(lhs.data / rhs.data);
-    auto result = Unit<def / U::def, ResultType>();
-    result.data = lhs.data / rhs.data;  // bypass constructor SI cast
-    return result;
+    if constexpr (SameDimensionAs<Unit, U>) {
+      return lhs.data / rhs.data;  // Unitless return since dimensions cancel
+    } else {
+      using ResultType = decltype(lhs.data / rhs.data);
+      auto result = Unit<def / U::def, ResultType>();
+      result.data = lhs.data / rhs.data;  // bypass constructor SI cast
+      return result;
+    }
   }
 };
 
@@ -184,9 +176,14 @@ constexpr auto operator*(IsArithmetic auto lhs, DR /*rhs*/) noexcept {
 
 template <IsUnit U, IsDefinition D>
 constexpr auto operator*(U lhs, D rhs) noexcept {
-  auto result = Unit<U::def * rhs, typename U::ValueType>();
-  result.data = lhs.data;
-  return result;
+  if constexpr (std::same_as<typename U::DefType::DimenType,
+                             DimensionFlip<typename D::DimenType>>) {
+    return lhs.data;
+  } else {
+    auto result = Unit<U::def * rhs, typename U::ValueType>();
+    result.data = lhs.data;
+    return result;
+  }
 }
 
 template <IsDefinition D>
@@ -196,9 +193,14 @@ constexpr auto operator/(IsArithmetic auto lhs, D rhs) noexcept {
 
 template <IsUnit U, IsDefinition D>
 constexpr auto operator/(U lhs, D rhs) noexcept {
-  auto result = Unit<U::def / rhs, typename U::ValueType>();
-  result.data = lhs.data;
-  return result;
+  if constexpr (std::same_as<typename U::DefType::DimenType,
+                             typename D::DimenType>) {
+    return lhs.data;
+  } else {
+    auto result = Unit<U::def / rhs, typename U::ValueType>();
+    result.data = lhs.data;
+    return result;
+  }
 }
 
 }  // namespace csm_units

--- a/test/source/math.cpp
+++ b/test/source/math.cpp
@@ -22,6 +22,9 @@ TEST_SUITE("Math utility functions") {
     CHECK_UNIT_EQ(UnitPow<2>(-2._m), 4._m2);
     CHECK_UNIT_EQ(UnitPow<3>(-2._m), -8._m3);
     CHECK_UNIT_EQ(UnitPow<4>(-2._m), 16._m3 * m);
+    CHECK_UNIT_EQ(UnitPow<-1>(-2._m), Unit<One() / m>(-0.5));
+    CHECK_UNIT_EQ(UnitPow<-2>(-2._m), 1 / 4_m2);
+    CHECK_UNIT_EQ(UnitPow<-3>(-2._m), -1 / 8_m3);
   }
 }
 // NOLINTEND(modernize-use-trailing-return-type, misc-use-anonymous-namespace)


### PR DESCRIPTION
Abandoned `detail::UnitPow` struct for `if constexpr` inside outer `UnitPow` function.

`UnitPow` now handles integer powers of any sign.