### PR TITLE
Implement scientific notation class to prevent conversion overflow

### DIFF
--- a/include/csm_units/concepts.hpp
+++ b/include/csm_units/concepts.hpp
@@ -25,6 +25,22 @@ concept IsRatio = requires {
 };
 
 /**
+ * \brief This concept enforces that a class is a scientific number.
+ */
+template <class T>
+concept IsSciNo = requires(T input) {
+  { typename std::remove_reference_t<decltype(input.mag)>() } -> IsRatio;
+  { input.ord } -> std::convertible_to<int>;
+};
+
+/**
+ * \brief This concept enforces that a class is a conversion factor type, that
+ * is a SciNo or std::ratio.
+ */
+template <class T>
+concept IsConversion = IsRatio<T> or IsSciNo<T>;
+
+/**
  * \brief This concept enforces the form of unit dimensions.
  * stated.
  */
@@ -52,8 +68,8 @@ concept IsDimension = requires {
 template <class D>
 concept IsDefinition = requires {
   { typename std::remove_reference_t<D>::DimenType() } -> IsDimension;
-  { typename std::remove_reference_t<D>::ConvType() } -> IsRatio;
-  { typename std::remove_reference_t<D>::OriginType() } -> IsRatio;
+  { typename std::remove_reference_t<D>::ConvType() } -> IsConversion;
+  { typename std::remove_reference_t<D>::OriginType() } -> IsConversion;
 };
 
 /**

--- a/include/csm_units/concepts.hpp
+++ b/include/csm_units/concepts.hpp
@@ -29,7 +29,7 @@ concept IsRatio = requires {
  */
 template <class T>
 concept IsSciNo = requires(T input) {
-  { typename std::remove_reference_t<decltype(input.mag)>() } -> IsRatio;
+  { typename std::remove_reference_t<T>::MagType() } -> IsRatio;
   { input.ord } -> std::convertible_to<int>;
 };
 

--- a/source/csm_units/definition.hpp
+++ b/source/csm_units/definition.hpp
@@ -81,30 +81,21 @@ class Definition {
 // Operator+,- with ratio sets Origin
 // Operator+ is symmetric, operator- with def rhs not supported due to
 // potentially unintuitive arithmetic
-template <IsConversion C, IsDefinition D>
-[[nodiscard]] constexpr auto operator+(C /*lhs*/, D /*rhs*/) noexcept {
-  if constexpr (IsRatio<C>) {
-    return Definition<typename D::DimenType, typename D::ConvType, C>();
-  } else {
-    return Definition<typename D::DimenType, typename D::ConvType,
-                      typename C::MagType>();
-  }
+template <IsRatio R, IsDefinition D>
+[[nodiscard]] constexpr auto operator+(R /*lhs*/, D /*rhs*/) noexcept {
+  return Definition<typename D::DimenType, typename D::ConvType,
+                    std::ratio_add<R, typename D::OriginType>>();
 }
 
 [[nodiscard]] constexpr auto operator+(IsDefinition auto lhs,
-                                       IsConversion auto rhs) noexcept {
+                                       IsRatio auto rhs) noexcept {
   return rhs + lhs;
 }
 
-template <IsDefinition D, IsConversion C>
-[[nodiscard]] constexpr auto operator-(D /*lhs*/, C /*rhs*/) noexcept {
-  if constexpr (IsRatio<C>) {
-    return Definition<typename D::DimenType, typename D::ConvType,
-                      std::ratio<-C::num, C::den>>();
-  } else {
-    return Definition<typename D::DimenType, typename D::ConvType,
-                      std::ratio<-C::MagType::num, C::MagType::den>>();
-  }
+template <IsDefinition D, IsRatio R>
+[[nodiscard]] constexpr auto operator-(D /*lhs*/, R /*rhs*/) noexcept {
+  return Definition<typename D::DimenType, typename D::ConvType,
+                    std::ratio_subtract<typename D::OriginType, R>>();
 }
 
 // Operator*,/ with ratio sets conversion factor

--- a/source/csm_units/definition.hpp
+++ b/source/csm_units/definition.hpp
@@ -12,6 +12,7 @@
 #include <ratio>
 
 #include "dimension.hpp"
+#include "sci_no.hpp"
 
 #ifndef CSMUNITS_VALUE_TYPE
 #define CSMUNITS_VALUE_TYPE double
@@ -21,16 +22,16 @@ namespace csm_units {
 
 namespace literals {
 
-using Inv = std::ratio<-1>;
-using Zero = std::ratio<0>;
-using One = std::ratio<1>;
-using Two = std::ratio<2>;
-using Three = std::ratio<3>;
+using Inv = SciNo<std::ratio<-1>>;
+using Zero = SciNo<std::ratio<0>>;
+using One = SciNo<std::ratio<1>>;
+using Two = SciNo<std::ratio<2>>;
+using Three = SciNo<std::ratio<3>>;
 
 }  // namespace literals
 
-template <IsDimension D, IsRatio ConversionFactor = literals::One,
-          IsRatio Origin = literals::Zero>
+template <IsDimension D, IsSciNo ConversionFactor = literals::One,
+          IsRatio Origin = std::ratio<0>>
 class Definition {
  public:
   using DimenType = D;
@@ -38,11 +39,11 @@ class Definition {
   using OriginType = Origin;
 
   [[nodiscard]] consteval static auto Get() noexcept {
-    return static_cast<CSMUNITS_VALUE_TYPE>(ConvType::num) / ConvType::den;
+    return SciNoDecimal<ConvType>;
   }
 
   [[nodiscard]] consteval static auto ToSI() noexcept {
-    return static_cast<CSMUNITS_VALUE_TYPE>(ConvType::den) / ConvType::num;
+    return static_cast<CSMUNITS_VALUE_TYPE>(1.0) / SciNoDecimal<ConvType>;
   }
 
   // Arithmetic helpers
@@ -50,15 +51,12 @@ class Definition {
   template <IsDefinition A>
   using DefinitionMultiply =
       Definition<DimensionAdd<DimenType, typename A::DimenType>,
-                 std::ratio_multiply<ConvType, typename A::ConvType>>;
+                 SciNoMultiply<ConvType, typename A::ConvType>>;
 
   template <IsDefinition A>
   using DefinitionDivide =
       Definition<DimensionSubtract<DimenType, typename A::DimenType>,
-                 std::ratio_divide<ConvType, typename A::ConvType>>;
-
-  using DefinitionInvert = Definition<DimensionFlip<DimenType>,
-                                      std::ratio<ConvType::den, ConvType::num>>;
+                 SciNoDivide<ConvType, typename A::ConvType>>;
 
   template <IsDefinition DR>
   [[nodiscard]] constexpr auto operator*(DR /*rhs*/) const noexcept {
@@ -83,45 +81,69 @@ class Definition {
 // Operator+,- with ratio sets Origin
 // Operator+ is symmetric, operator- with def rhs not supported due to
 // potentially unintuitive arithmetic
-template <IsRatio R, IsDefinition D>
-[[nodiscard]] constexpr auto operator+(R /*lhs*/, D /*rhs*/) noexcept {
-  return Definition<typename D::DimenType, typename D::ConvType, R>();
+template <IsConversion C, IsDefinition D>
+[[nodiscard]] constexpr auto operator+(C /*lhs*/, D /*rhs*/) noexcept {
+  if constexpr (IsRatio<C>) {
+    return Definition<typename D::DimenType, typename D::ConvType, C>();
+  } else {
+    return Definition<typename D::DimenType, typename D::ConvType,
+                      typename C::MagType>();
+  }
 }
 
-template <IsDefinition D, IsRatio R>
-[[nodiscard]] constexpr auto operator+(D /*lhs*/, R /*rhs*/) noexcept {
-  return Definition<typename D::DimenType, typename D::ConvType, R>();
+[[nodiscard]] constexpr auto operator+(IsDefinition auto lhs,
+                                       IsConversion auto rhs) noexcept {
+  return rhs + lhs;
 }
 
-template <IsDefinition D, IsRatio R>
-[[nodiscard]] constexpr auto operator-(D /*lhs*/, R /*rhs*/) noexcept {
-  return Definition<typename D::DimenType, typename D::ConvType,
-                    std::ratio<-1 * R::num, R::den>>();
+template <IsDefinition D, IsConversion C>
+[[nodiscard]] constexpr auto operator-(D /*lhs*/, C /*rhs*/) noexcept {
+  if constexpr (IsRatio<C>) {
+    return Definition<typename D::DimenType, typename D::ConvType,
+                      std::ratio<-C::num, C::den>>();
+  } else {
+    return Definition<typename D::DimenType, typename D::ConvType,
+                      std::ratio<-C::MagType::num, C::MagType::den>>();
+  }
 }
 
 // Operator*,/ with ratio sets conversion factor
-template <IsDefinition D, IsRatio R>
-[[nodiscard]] constexpr auto operator*(D /*lhs*/, R /*rhs*/) noexcept {
-  return Definition<typename D::DimenType,
-                    std::ratio_multiply<typename D::ConvType, R>>();
+template <IsDefinition D, IsConversion C>
+[[nodiscard]] constexpr auto operator*(D /*lhs*/, C /*rhs*/) noexcept {
+  if constexpr (IsRatio<C>) {
+    return Definition<typename D::DimenType,
+                      SciNoMultiply<typename D::ConvType, SciNo<C>>>();
+  } else {
+    return Definition<typename D::DimenType,
+                      SciNoMultiply<typename D::ConvType, C>>();
+  }
 }
 
-template <IsRatio R, IsDefinition D>
-[[nodiscard]] constexpr auto operator*(R /*lhs*/, D /*rhs*/) noexcept {
-  return Definition<typename D::DimenType,
-                    std::ratio_multiply<R, typename D::ConvType>>();
+[[nodiscard]] constexpr auto operator*(IsConversion auto lhs,
+                                       IsDefinition auto rhs) noexcept {
+  return rhs * lhs;
 }
 
-template <IsDefinition D, IsRatio R>
-[[nodiscard]] constexpr auto operator/(D /*lhs*/, R /*rhs*/) noexcept {
-  return Definition<typename D::DimenType,
-                    std::ratio_divide<typename D::ConvType, R>>();
+template <IsDefinition D, IsConversion C>
+[[nodiscard]] constexpr auto operator/(D /*lhs*/, C /*rhs*/) noexcept {
+  if constexpr (IsRatio<C>) {
+    return Definition<typename D::DimenType,
+                      SciNoDivide<typename D::ConvType, SciNo<C>>>();
+  } else {
+    return Definition<typename D::DimenType,
+                      SciNoDivide<typename D::ConvType, C>>();
+  }
 }
 
-template <IsRatio R, IsDefinition D>
-[[nodiscard]] constexpr auto operator/(R /*lhs*/, D /*rhs*/) noexcept {
-  return Definition<DimensionFlip<typename D::DimenType>,
-                    std::ratio_divide<R, typename D::ConvType>>();
+template <IsConversion C, IsDefinition D>
+[[nodiscard]] constexpr auto operator/(C /*lhs*/, D /*rhs*/) noexcept {
+  if constexpr (IsRatio<C>) {
+    return Definition<DimensionFlip<typename D::DimenType>,
+                      SciNoDivide<SciNo<C>, typename D::ConvType>>();
+  } else {
+    return Definition<DimensionFlip<typename D::DimenType>,
+                      SciNoDivide<C, typename D::ConvType>>();
+  }
 }
 
 }  // namespace csm_units

--- a/source/csm_units/sci_no.hpp
+++ b/source/csm_units/sci_no.hpp
@@ -17,7 +17,7 @@ class SciNo {
   };
 
  public:
-  constexpr static auto ord = [] consteval {
+  constexpr static auto ord = []() consteval {
     constexpr auto num = StaticAbs<Mag::num / Mag::den>::value;
     if constexpr (Mag::num == 0) {
       return 0;
@@ -29,7 +29,7 @@ class SciNo {
       return Order;
     }
   }();
-  constexpr static auto mag = [] consteval {
+  constexpr static auto mag = []() consteval {
     if constexpr (ord > Order) {
       return SciNo<std::ratio_multiply<Mag, std::ratio<1, 10>>, Order>::mag;
     } else if constexpr (ord < Order) {

--- a/source/csm_units/sci_no.hpp
+++ b/source/csm_units/sci_no.hpp
@@ -1,0 +1,109 @@
+// replace std::ratio to avoid overflowing LL from conversions such as nm3
+#pragma once
+#include <csm_units/concepts.hpp>
+#include <ratio>
+
+#ifndef CSMUNITS_VALUE_TYPE
+#define CSMUNITS_VALUE_TYPE double
+#endif
+
+namespace csm_units {
+
+template <IsRatio Mag, int Order = 0>
+class SciNo {
+  template <int n>
+  struct StaticAbs {
+    constexpr static int value = n < 0 ? -n : n;
+  };
+
+ public:
+  constexpr static auto ord = [] consteval {
+    constexpr auto num = StaticAbs<Mag::num / Mag::den>::value;
+    if constexpr (Mag::num == 0) {
+      return 0;
+    } else if constexpr (num >= 10) {
+      return SciNo<std::ratio_multiply<Mag, std::ratio<1, 10>>, Order>::ord + 1;
+    } else if constexpr (num < 1) {
+      return SciNo<std::ratio_multiply<Mag, std::ratio<10, 1>>, Order>::ord - 1;
+    } else {
+      return Order;
+    }
+  }();
+  constexpr static auto mag = [] consteval {
+    if constexpr (ord > Order) {
+      return SciNo<std::ratio_multiply<Mag, std::ratio<1, 10>>, Order>::mag;
+    } else if constexpr (ord < Order) {
+      return SciNo<std::ratio_multiply<Mag, std::ratio<10, 1>>, Order>::mag;
+    } else {
+      return Mag();
+    }
+  }();
+
+  using MagType = decltype(mag);
+};
+
+namespace detail {
+
+template <IsSciNo L, IsSciNo R>
+struct SciNoMultiply {
+  using type =
+      SciNo<std::ratio_multiply<typename L::MagType, typename R::MagType>,
+            L::ord + R::ord>;
+};
+
+template <IsSciNo L, IsSciNo R>
+struct SciNoDivide {
+  using type =
+      SciNo<std::ratio_divide<typename L::MagType, typename R::MagType>,
+            L::ord - R::ord>;
+};
+
+template <IsSciNo L, IsSciNo R>
+struct SciNoEqual
+    : std::bool_constant<
+          std::ratio_equal_v<typename L::MagType, typename R::MagType> and
+          L::ord == R::ord> {};
+
+template <IsSciNo L, IsSciNo R>
+struct SciNoNotEqual
+    : std::bool_constant<
+          std::ratio_not_equal_v<typename L::MagType, typename R::MagType> or
+          L::ord != R::ord> {};
+
+template <IsSciNo S>
+class SciNoDecimal {
+  template <int N>
+  [[nodiscard]] constexpr static auto StaticPow() noexcept {
+    if constexpr (N > 0) {
+      return 10 * StaticPow<N - 1>();
+    } else if constexpr (N < 0) {
+      return 1 / StaticPow<-N>();
+    } else {
+      return 1.0;
+    }
+  }
+
+ public:
+  constexpr static auto value =
+      static_cast<CSMUNITS_VALUE_TYPE>(S::MagType::num) / S::MagType::den *
+      StaticPow<S::ord>();
+};
+
+}  // namespace detail
+
+template <IsSciNo L, IsSciNo R>
+using SciNoMultiply = detail::SciNoMultiply<L, R>::type;
+
+template <IsSciNo L, IsSciNo R>
+using SciNoDivide = detail::SciNoDivide<L, R>::type;
+
+template <IsSciNo L, IsSciNo R>
+constexpr auto SciNoEqual = detail::SciNoEqual<L, R>::value;
+
+template <IsSciNo L, IsSciNo R>
+constexpr auto SciNoNotEqual = detail::SciNoNotEqual<L, R>::value;
+
+template <IsSciNo S>
+constexpr auto SciNoDecimal = detail::SciNoDecimal<S>::value;
+
+}  // namespace csm_units

--- a/source/csm_units/sci_no.hpp
+++ b/source/csm_units/sci_no.hpp
@@ -17,7 +17,7 @@ class SciNo {
   };
 
  public:
-  constexpr static auto ord = []() consteval {
+  constexpr static auto ord = [] {
     constexpr auto num = StaticAbs<Mag::num / Mag::den>::value;
     if constexpr (Mag::num == 0) {
       return 0;
@@ -29,7 +29,7 @@ class SciNo {
       return Order;
     }
   }();
-  constexpr static auto mag = []() consteval {
+  constexpr static auto mag = [] {
     if constexpr (ord > Order) {
       return SciNo<std::ratio_multiply<Mag, std::ratio<1, 10>>, Order>::mag;
     } else if constexpr (ord < Order) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   source/unit.cpp
   source/arithmetic.cpp
   source/comparison.cpp
+  source/sci_no.cpp
   source/definition.cpp
   source/size.cpp
   source/named_units/absorbed_dose.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,7 +67,9 @@ set_property(
 # Compiler Properties for testing
 target_compile_features(${PROJECT_NAME}_test PRIVATE cxx_std_23)
 if(MSVC)
-  target_compile_options(${PROJECT_NAME}_test PRIVATE /bigobj /W4 /WX)
+  target_compile_options(
+    ${PROJECT_NAME}_test PRIVATE /bigobj /W4 /WX /std:c++latest
+  )
 else()
   target_compile_options(
     ${PROJECT_NAME}_test PRIVATE -g -Wall -Wextra -Wpedantic -Werror -std=c++2b

--- a/test/source/definition.cpp
+++ b/test/source/definition.cpp
@@ -15,13 +15,15 @@ namespace csm_units::test {
 
 TEST_SUITE("Definition") {
   using namespace csm_units::literals;
-  using length_def = Definition<Dimension<One>>;
+  using length_def = Definition<DimensionInt<1>>;
   using inv_def = decltype(One() / length_def());
   using area_def = decltype(length_def() * length_def());
   using dimensionless = decltype(length_def() / length_def());
   TEST_CASE("Construction via operator*") {
-    static_assert(std::is_same_v<length_def::DimenType, Dimension<One>>);
-    static_assert(std::is_same_v<area_def::DimenType, Dimension<Two>>);
+    static_assert(
+        std::is_same_v<length_def::DimenType, Dimension<std::ratio<1>>>);
+    static_assert(
+        std::is_same_v<area_def::DimenType, Dimension<std::ratio<2>>>);
     static_assert(std::is_same_v<dimensionless, CSMUNITS_VALUE_TYPE>);
     static_assert(
         std::is_same_v<decltype(area_def() / length_def()), length_def>);

--- a/test/source/sci_no.cpp
+++ b/test/source/sci_no.cpp
@@ -1,0 +1,125 @@
+#include <doctest/doctest.h>
+
+#include <ratio>
+#include <source/csm_units/sci_no.hpp>
+
+#ifndef CSMUNITS_VALUE_TYPE
+#define CSMUNITS_VALUE_TYPE double
+#endif
+
+namespace csm_units::test {
+
+// NOLINTBEGIN(modernize-use-trailing-return-type, misc-use-anonymous-namespace)
+
+TEST_SUITE("SciNo") {
+  using namespace csm_units;
+  TEST_CASE("Equal") {
+    using RHS = SciNo<std::ratio<2, 3>, 2>;
+    static_assert(SciNoEqual<SciNo<std::ratio<2, 3>, 2>, RHS>);
+    static_assert(not SciNoNotEqual<SciNo<std::ratio<2, 3>, 2>, RHS>);
+
+    static_assert(SciNoEqual<SciNo<std::ratio<4, 6>, 2>, RHS>);
+    static_assert(not SciNoNotEqual<SciNo<std::ratio<4, 6>, 2>, RHS>);
+
+    static_assert(SciNoEqual<SciNo<std::ratio<40, 6>, 1>, RHS>);
+    static_assert(not SciNoEqual<SciNo<std::ratio<2, 4>, 2>, RHS>);
+
+    static_assert(not SciNoEqual<SciNo<std::ratio<4, 3>, 2>, RHS>);
+    static_assert(SciNoNotEqual<SciNo<std::ratio<2, 4>, 2>, RHS>);
+
+    static_assert(not SciNoEqual<SciNo<std::ratio<2, 3>, -2>, RHS>);
+    static_assert(SciNoNotEqual<SciNo<std::ratio<2, 3>, -2>, RHS>);
+
+    static_assert(not SciNoEqual<SciNo<std::ratio<40, 6>, 2>, RHS>);
+    static_assert(SciNoNotEqual<SciNo<std::ratio<40, 6>, 2>, RHS>);
+  }
+
+  TEST_CASE("Constructor and reductions") {
+    SUBCASE("No reduction") {
+      const int num = 5;
+      const int den = 4;
+      const int order = 1;
+      static_assert(csm_units::SciNo<std::ratio<num, den>, order>::ord ==
+                    order);
+      static_assert(csm_units::SciNo<std::ratio<num, den>, order>::mag.num ==
+                    std::ratio<num, den>::num);
+      static_assert(csm_units::SciNo<std::ratio<num, den>, order>::mag.den ==
+                    std::ratio<num, den>::den);
+    }
+    SUBCASE("Input mag < 1") {
+      using LHS = csm_units::SciNo<std::ratio<3, 4>, 1>;
+      static_assert(LHS::ord == 0);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<15, 2>>);
+    }
+    SUBCASE("Input mag < 0.1") {
+      using LHS = csm_units::SciNo<std::ratio<3, 40>, 1>;
+      static_assert(LHS::ord == -1);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<15, 2>>);
+    }
+    SUBCASE("Input mag > -1 && < 0") {
+      using LHS = csm_units::SciNo<std::ratio<-3, 4>, 1>;
+      static_assert(LHS::ord == 0);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<-15, 2>>);
+    }
+    SUBCASE("Input mag > 10") {
+      using LHS = csm_units::SciNo<std::ratio<50, 3>, 1>;
+      static_assert(LHS::ord == 2);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<5, 3>>);
+    }
+    SUBCASE("Input mag > 100") {
+      using LHS = csm_units::SciNo<std::ratio<500, 3>, 1>;
+      static_assert(LHS::ord == 3);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<5, 3>>);
+    }
+    SUBCASE("Order = 2, mag > 10") {
+      using LHS = csm_units::SciNo<std::ratio<50, 3>, 2>;
+      static_assert(LHS::ord == 3);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<5, 3>>);
+    }
+    SUBCASE("Order = -1, mag > 10") {
+      using LHS = csm_units::SciNo<std::ratio<50, 3>, -1>;
+      static_assert(LHS::ord == 0);
+      static_assert(std::ratio_equal_v<LHS::MagType, std::ratio<5, 3>>);
+    }
+  }
+  TEST_CASE("Multiply") {
+    using LHS = SciNo<std::ratio<3, 4>, 0>;
+    using RHS = SciNo<std::ratio<4, 3>, 0>;
+    static_assert(SciNoEqual<SciNoMultiply<LHS, RHS>, SciNo<std::ratio<1>, 0>>);
+  }
+
+  TEST_CASE("Divide") {
+    using LHS = SciNo<std::ratio<3, 4>, 0>;
+    using RHS = SciNo<std::ratio<4, 3>, 0>;
+    static_assert(
+        SciNoEqual<SciNoDivide<LHS, RHS>, SciNo<std::ratio<9, 16>, 0>>);
+    static_assert(
+        SciNoEqual<SciNoDivide<LHS, RHS>, SciNo<std::ratio<45, 8>, -1>>);
+  }
+
+  // TEST_CASE("To Ratio") {
+  //   {
+  //     const auto scino = SciNo<std::ratio<3, 4>, 0>();
+
+  //     static_assert(std::same_as<decltype(ToRatio(scino)), std::ratio<3,
+  //     4>>);
+  //   }
+  //   {
+  //     const auto scino = SciNo<std::ratio<30, 4>, 0>();
+
+  //     static_assert(std::same_as<decltype(ToRatio(scino)), std::ratio<30,
+  //     4>>);
+  //   }
+
+  //   {
+  //     const auto scino = SciNo<std::ratio<3, 40>, 0>();
+
+  //     static_assert(std::same_as<decltype(ToRatio(scino)), std::ratio<3,
+  //     40>>);
+  //   }
+  // }
+}
+
+// NOLINTEND(modernize-use-trailing-return-type, misc-use-anonymous-namespace)
+
+}  // namespace csm_units::test

--- a/test/source/sci_no.cpp
+++ b/test/source/sci_no.cpp
@@ -41,10 +41,9 @@ TEST_SUITE("SciNo") {
       const int order = 1;
       static_assert(csm_units::SciNo<std::ratio<num, den>, order>::ord ==
                     order);
-      static_assert(csm_units::SciNo<std::ratio<num, den>, order>::mag.num ==
-                    std::ratio<num, den>::num);
-      static_assert(csm_units::SciNo<std::ratio<num, den>, order>::mag.den ==
-                    std::ratio<num, den>::den);
+      static_assert(
+          std::same_as<csm_units::SciNo<std::ratio<num, den>, order>::MagType,
+                       std::ratio<num, den>>);
     }
     SUBCASE("Input mag < 1") {
       using LHS = csm_units::SciNo<std::ratio<3, 4>, 1>;


### PR DESCRIPTION
`Definition::ConvType` update `std::ratio` $\Longrightarrow$ `csm_units::SciNo`.

Implement `SciNo<std::ratio, int>` as an `std::ratio` with addition $10^n$ term to store exceedingly large and small values as template parameters. Fixes a limitation of `std::ratio`, which prevented storing the needed conversions for large and small unit types such as cubic nanometers. In such cases, the required conversion factor (i.e. $10^{18}$) exceeded the maximum of `intmax_t` (i.e. `long long`) as part of `std::ratio::num` or `std::ratio::den`.

Units may be built from either `std::ratio` or `SciNo`, i.e. `Unit<std::ratio<100> * m>` or `Unit<SciNo<std::ratio<1>, 2> * m>`