### PR TITLE
UnitSqrt NaN Check

### DIFF
--- a/source/csm_units/math.hpp
+++ b/source/csm_units/math.hpp
@@ -42,10 +42,13 @@ template <int N, class T>
 struct Root {
   constexpr auto operator()(T input) const noexcept {
     constexpr auto abs = [](auto&& n) { return n < 0 ? -n : n; };
-    auto value = T{1};
     const auto coeffs = std::pair<T, T>{static_cast<double>(N - 1) / N,
                                         static_cast<double>(input) / N};
-    for (auto pow = Pow<N - 1, T>()(value); abs(pow * value - input) > 1e-12;) {
+    auto value = input / T{N};
+    auto pow = T{1};
+    for (int count = 0; count < 1000 and abs(pow * value - input) >=
+                                             std::numeric_limits<T>::min();
+         ++count) {
       value = coeffs.first * value + coeffs.second / pow;
       pow = Pow<N - 1, T>()(value);
     }

--- a/source/csm_units/math.hpp
+++ b/source/csm_units/math.hpp
@@ -82,35 +82,39 @@ template <IsRatio R, IsUnit U,
     if (unit.data < 0.0 and R::den % 2 == 0) {  // check for imaginary answer
       return BaseUnit(std::numeric_limits<double>::quiet_NaN());
     }
-    return BaseUnit(
-        detail::Pow<R::num, Data>()(RootF(std::forward<Data>(unit.data))));
+    return BaseUnit(detail::Pow<R::num, Data>()(RootF(unit.data)));
   }
 }
 
 // Alias with two integer templates
 template <int N, int D = 1>
 [[nodiscard]] constexpr auto UnitPow(IsUnit auto&& unit) noexcept {
-  return UnitPow<std::ratio<N, D>>(std::forward<decltype(unit)>(unit));
+  return UnitPow<std::ratio<N, D>>(
+      std::forward<std::remove_reference_t<decltype(unit)>>(unit));
 }
 
 // Alias for unit square root
 [[nodiscard]] constexpr auto UnitSqrt(IsUnit auto&& unit) noexcept {
-  return UnitPow<std::ratio<1, 2>>(std::forward<decltype(unit)>(unit));
+  return UnitPow<std::ratio<1, 2>>(
+      std::forward<std::remove_reference_t<decltype(unit)>>(unit));
 }
 
 // Alias for unit cubic root
 [[nodiscard]] constexpr auto UnitCbrt(IsUnit auto&& unit) noexcept {
-  return UnitPow<std::ratio<1, 3>>(std::forward<decltype(unit)>(unit));
+  return UnitPow<std::ratio<1, 3>>(
+      std::forward<std::remove_reference_t<decltype(unit)>>(unit));
 }
 
 // Alias for unit square
 [[nodiscard]] constexpr auto UnitSquare(IsUnit auto&& unit) noexcept {
-  return UnitPow<2>(std::forward<decltype(unit)>(unit));
+  return UnitPow<2>(
+      std::forward<std::remove_reference_t<decltype(unit)>>(unit));
 }
 
 // Alias for unit cube
 [[nodiscard]] constexpr auto UnitCube(IsUnit auto&& unit) noexcept {
-  return UnitPow<3>(std::forward<decltype(unit)>(unit));
+  return UnitPow<3>(
+      std::forward<std::remove_reference_t<decltype(unit)>>(unit));
 }
 
 }  // namespace csm_units

--- a/test/source/math.cpp
+++ b/test/source/math.cpp
@@ -1,5 +1,6 @@
 #include <doctest/doctest.h>
 
+#include <cmath>
 #include <csm_units/units.hpp>
 #include <ratio>
 #include <source/csm_units/math.hpp>

--- a/test/source/math.cpp
+++ b/test/source/math.cpp
@@ -37,6 +37,7 @@ TEST_SUITE("Math utility functions") {
     CHECK_DBL_EQ(UnitPow<std::ratio<-0, 1>>(10._m2), 1);
     CHECK(std::isnan(UnitPow<std::ratio<1, 2>>(-4._m2).data));
     CHECK_UNIT_EQ(UnitPow<std::ratio<1, 3>>(-8._m3), -2_m);
+    CHECK_UNIT_EQ(UnitPow<std::ratio<1, 2>>(0._m2), 0_m);
     CHECK_UNIT_EQ(  // Check arbitrary root function, here just return 10
         UnitPow<std::ratio<-3, 2>, SqMeter,
                 [](typename SqMeter::ValueType) { return 10; }>(10._m2),

--- a/test/source/math.cpp
+++ b/test/source/math.cpp
@@ -34,6 +34,8 @@ TEST_SUITE("Math utility functions") {
     CHECK_UNIT_EQ(UnitPow<3, 2>(10. * cm * cm), 3.16228e-05_m3);
     CHECK_UNIT_EQ(UnitPow<std::ratio<-3, 2>>(10._m2), 0.0316227766 / m3);
     CHECK_DBL_EQ(UnitPow<std::ratio<-0, 1>>(10._m2), 1);
+    CHECK(std::isnan(UnitPow<std::ratio<1, 2>>(-4._m2).data));
+    CHECK_UNIT_EQ(UnitPow<std::ratio<1, 3>>(-8._m3), -2_m);
     CHECK_UNIT_EQ(  // Check arbitrary root function, here just return 10
         UnitPow<std::ratio<-3, 2>, SqMeter,
                 [](typename SqMeter::ValueType) { return 10; }>(10._m2),


### PR DESCRIPTION
`UnitPow` now checks for NaN result (negative unit data, odd power denominator) and returns `BaseUnit(quite_NaN())` when appropriate.

Improved `UnitPow` adhoc concept by requiring `RootF` return type convertible to `T`. 

`Root` loop now tracks iteration number and stops if max count reached.