### PR TITLE
Template Get for Explicit Conversions

### DIFF
--- a/source/csm_units/unit.hpp
+++ b/source/csm_units/unit.hpp
@@ -49,10 +49,17 @@ class Unit {
   constexpr explicit(false) Unit(SameDimensionAs<Unit> auto input) noexcept
       : data(input.data) {}
 
-  // Return magnitude in expected named unit by applying conversion
+  // Return magnitude in expected named unit by applying conversion dictated by
+  // template
+  template <Definition out_def = definition>
+    requires requires {
+      { typename decltype(out_def)::DimenType{} } -> std::same_as<DimenType>;
+    }
   [[nodiscard]] constexpr auto Get() const noexcept {
-    return (data * DefType::Get()) -
-           static_cast<ValueType>(OriginType::num) / OriginType::den;
+    using OutDefType = decltype(out_def);
+    using OutOriginType = typename OutDefType::OriginType;
+    return (data * OutDefType::Get()) -
+           static_cast<ValueType>(OutOriginType::num) / OutOriginType::den;
   }
 
   // Return magnitude in si, a getter for var data for readability if desired

--- a/test/source/unit.cpp
+++ b/test/source/unit.cpp
@@ -23,6 +23,8 @@ TEST_SUITE("Unit") {
     CHECK_DBL_EQ(Fahrenheit(100.).Get<K>(), Fahrenheit(100.).data);
     CHECK_DBL_EQ(Fahrenheit(100.).Get<degF>(), Fahrenheit(100.).Get());
     CHECK_DBL_EQ(Kelvin(100.).Get<degF>(), Fahrenheit(-279.67).Get());
+    CHECK_DBL_EQ(Fahrenheit(100.).Get<degC>(), 37.7778);
+    CHECK_DBL_EQ(Fahrenheit(100.).Get(), 100.);
     CHECK_DBL_EQ(Fahrenheit(100.).data, Rankine(559.67).data);
     CHECK_DBL_EQ(Fahrenheit(100.).data, Celsius(37.7778).data);
     CHECK_DBL_EQ(Fahrenheit(100.).Get<degC>(), Celsius(37.7778).Get());

--- a/test/source/unit.cpp
+++ b/test/source/unit.cpp
@@ -20,8 +20,12 @@ TEST_SUITE("Unit") {
     CHECK_DBL_EQ(Rankine(100.).data, 100. * 5 / 9);
     static_assert(Kelvin(100.).Get() == Kelvin(100.).data);
     CHECK_DBL_EQ(Fahrenheit(100.).Get(), 100);
+    CHECK_DBL_EQ(Fahrenheit(100.).Get<K>(), Fahrenheit(100.).data);
+    CHECK_DBL_EQ(Fahrenheit(100.).Get<degF>(), Fahrenheit(100.).Get());
+    CHECK_DBL_EQ(Kelvin(100.).Get<degF>(), Fahrenheit(-279.67).Get());
     CHECK_DBL_EQ(Fahrenheit(100.).data, Rankine(559.67).data);
     CHECK_DBL_EQ(Fahrenheit(100.).data, Celsius(37.7778).data);
+    CHECK_DBL_EQ(Fahrenheit(100.).Get<degC>(), Celsius(37.7778).Get());
     CHECK_DBL_EQ(Fahrenheit(100.).data, Rankine(100 + 459.67).data);
     CHECK_EQ(Fahrenheit(100.).data,
              doctest::Approx(Kelvin((100 - 32) * 5. / 9 + 273.15).Get()));


### PR DESCRIPTION
Added template to `Unit::Get()` to allow explicitly defined conversion to yield desired arithmetic result.

i.e. 

```c++
const auto unit = 3._cm;
auto dbl = unit.data; // 0.03
dbl = unit.Get<m>(); // 0.03
dbl = unit.Get<cm>(); // 3
dbl = unit.Get(); // 3
dbl = unit.Get<degC>(); // static error
```