### PR TITLE
Corrected incorrect operatorx(unit,def) arithmetic

### DIFF
--- a/source/csm_units/unit.hpp
+++ b/source/csm_units/unit.hpp
@@ -181,14 +181,7 @@ constexpr auto operator*(IsArithmetic auto lhs, DR /*rhs*/) noexcept {
 
 template <IsUnit U, IsDefinition D>
 constexpr auto operator*(U lhs, D rhs) noexcept {
-  if constexpr (std::same_as<typename U::DefType::DimenType,
-                             DimensionFlip<typename D::DimenType>>) {
-    return lhs.data;
-  } else {
-    auto result = Unit<U::def * rhs, typename U::ValueType>();
-    result.data = lhs.data / rhs.Get();
-    return result;
-  }
+  return lhs * Unit<rhs, typename U::ValueType>(typename U::ValueType{1});
 }
 
 template <IsDefinition D>
@@ -198,14 +191,7 @@ constexpr auto operator/(IsArithmetic auto lhs, D rhs) noexcept {
 
 template <IsUnit U, IsDefinition D>
 constexpr auto operator/(U lhs, D rhs) noexcept {
-  if constexpr (std::same_as<typename U::DefType::DimenType,
-                             typename D::DimenType>) {
-    return lhs.data;
-  } else {
-    auto result = Unit<U::def / rhs, typename U::ValueType>();
-    result.data = lhs.data * rhs.Get();
-    return result;
-  }
+  return lhs / Unit<rhs, typename U::ValueType>(typename U::ValueType{1});
 }
 
 }  // namespace csm_units

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,7 +68,7 @@ set_property(
 target_compile_features(${PROJECT_NAME}_test PRIVATE cxx_std_23)
 if(MSVC)
   target_compile_options(
-    ${PROJECT_NAME}_test PRIVATE /bigobj /W4 /WX /std:c++latest
+    ${PROJECT_NAME}_test PRIVATE /bigobj /W4 /WX /std:c++latest /GL
   )
 else()
   target_compile_options(

--- a/test/source/definition.cpp
+++ b/test/source/definition.cpp
@@ -1,9 +1,12 @@
 #include <doctest/doctest.h>
 
 #include <csm_units/concepts.hpp>
+#include <csm_units/units.hpp>
 #include <source/csm_units/definition.hpp>
 #include <source/csm_units/dimension.hpp>
 #include <source/csm_units/unit.hpp>
+
+#include "common.hpp"
 
 #ifndef CSMUNITS_VALUE_TYPE
 #define CSMUNITS_VALUE_TYPE double
@@ -28,6 +31,11 @@ TEST_SUITE("Definition") {
     static_assert(
         std::is_same_v<decltype(area_def() / length_def()), length_def>);
     static_assert(std::is_same_v<decltype(length_def() / area_def()), inv_def>);
+  }
+  TEST_CASE("Binary operations") {
+    CHECK_UNIT_EQ(12_Jpermol, 36_J / 3_mol);
+    CHECK_DBL_EQ(300., 300._bar / bar);
+    CHECK_UNIT_EQ(100_m2, 0.1_km * 1._m);
   }
 }
 

--- a/test/source/unit.cpp
+++ b/test/source/unit.cpp
@@ -31,7 +31,6 @@ TEST_SUITE("Unit") {
     CHECK_DBL_EQ(Fahrenheit(100.).data, Rankine(100 + 459.67).data);
     CHECK_EQ(Fahrenheit(100.).data,
              doctest::Approx(Kelvin((100 - 32) * 5. / 9 + 273.15).Get()));
-    CHECK_UNIT_EQ(12_Jpermol, 36_J / 3_mol);
   }
 }
 // NOLINTEND(modernize-use-trailing-return-type, misc-use-anonymous-namespace)


### PR DESCRIPTION
Main branch incorrectly evaluates i.e. `300._bar / literals::bar` as `3e-7`.

Issue resolved. `Unit::operator*(Unit, Definition)` and `Unit::operator/(Unit, Definition)` now construct temporary `Unit` for rhs and forward along to appropriate binary `(Unit, Unit)` operator overload.